### PR TITLE
Basic Ruby: Loops: Fix misspelling of 'Froot Loops' in loops.md

### DIFF
--- a/ruby/basic_ruby/loops.md
+++ b/ruby/basic_ruby/loops.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Not to be confused with Fruit Loops, the addictive cereal that causes symptoms similar to ADHD in kids, loops in Ruby are blocks of code that are continually repeated until a certain condition is met.
+Not to be confused with Froot Loops, the addictive cereal that causes symptoms similar to ADHD in kids, loops in Ruby are blocks of code that are continually repeated until a certain condition is met.
 
 Like me, you've probably experienced real-life loops when you were given detention in school and forced to repeatedly write the same line about not drawing small phallic shapes on your desk. Writing the same thing over and over and over is not only boring but also potentially error prone. You might have made a spelling mistake on one line and forgotten to dot an "i" on another line. It's the same with programming: the less code you have to write, the less chance you have of introducing bugs that can cause your program to crash and burn.
 


### PR DESCRIPTION
It is a common misconception that the spelling is 'Fruit Loops' but it is actually 'Froot Loops'.

Here is [an interesting article about the spelling of Froot Loops](https://www.wikihow.com/Fruit-Loops-Mandela-Effect).

## Because
To fix the misspelled name "Fruit Loops"

## This PR
* Corrects the spelling to "Froot Loops"

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
